### PR TITLE
chore: cleanup venv settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ parts/
 sdist/
 var/
 wheels/
+.venv*
 *.egg-info/
 .installed.cfg
 *.egg

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = C:\Users\USER\AppData\Local\Programs\Python\Python310
-include-system-site-packages = false
-version = 3.10.7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Expanded ignore patterns to exclude local Python virtual environment directories (e.g., .venv), reducing unnecessary files in version control.
  - Removed an accidental virtual environment configuration file from the repository to prevent environment-specific settings from being tracked.
  - No user-facing behavior changes; these updates streamline repository hygiene and developer workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->