### PR TITLE
feat: add export_report method to support JSON, Markdown, and HTML report formats in report generator

### DIFF
--- a/audit_engine/core/report_generator.py
+++ b/audit_engine/core/report_generator.py
@@ -32,3 +32,54 @@ class AuditReportGenerator:
             "scores": self.scores,
         }
         return report
+
+    def export_report(self, output_format: str = "json") -> str:
+        report = self.generate_report()
+        if output_format == "json":
+            return json.dumps(report, indent=2)
+        elif output_format == "markdown":
+            return self._to_markdown(report)
+        elif output_format == "html":
+            return self._to_html(report)
+        else:
+            raise ValueError(f"Unsupported output format: {output_format}")
+
+    def _to_markdown(self, report: Dict[str, Any]) -> str:
+        md = "# Audit Report\n"
+        if report.get("metadata"):
+            md += "## Metadata\n"
+            for k, v in report["metadata"].items():
+                md += f"- **{k}**: {v}\n"
+        md += "\n## Static Analysis Findings\n"
+        for finding in report["static_analysis"]:
+            md += f"- {finding}\n"
+        md += "\n## Dynamic Analysis Findings\n"
+        for finding in report["dynamic_analysis"]:
+            md += f"- {finding}\n"
+        md += "\n## Scoring\n"
+        for score in report["scores"]:
+            md += f"- {score}\n"
+        return md
+
+    def _to_html(self, report: Dict[str, Any]) -> str:
+        html = ["<html><head><title>Audit Report</title></head><body>"]
+        html.append("<h1>Audit Report</h1>")
+        if report.get("metadata"):
+            html.append("<h2>Metadata</h2><ul>")
+            for k, v in report["metadata"].items():
+                html.append(f"<li><strong>{k}</strong>: {v}</li>")
+            html.append("</ul>")
+        html.append("<h2>Static Analysis Findings</h2><ul>")
+        for finding in report["static_analysis"]:
+            html.append(f"<li>{finding}</li>")
+        html.append("</ul>")
+        html.append("<h2>Dynamic Analysis Findings</h2><ul>")
+        for finding in report["dynamic_analysis"]:
+            html.append(f"<li>{finding}</li>")
+        html.append("</ul>")
+        html.append("<h2>Scoring</h2><ul>")
+        for score in report["scores"]:
+            html.append(f"<li>{score}</li>")
+        html.append("</ul>")
+        html.append("</body></html>")
+        return "".join(html)


### PR DESCRIPTION
Add Markdown and HTML export support to AuditReportGenerator for flexible report output formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exportable audit reports combining metadata, static and dynamic findings, and scoring.
  * Reports can be exported as pretty JSON, Markdown documents, or HTML pages for easy sharing and review.
  * Clear error feedback when an unsupported export format is requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->