### PR TITLE
Add save_report method to AuditReportGenerator for direct file export in any supported format

### DIFF
--- a/audit_engine/core/report_generator.py
+++ b/audit_engine/core/report_generator.py
@@ -6,6 +6,15 @@ import json
 from typing import List, Dict, Any
 
 class AuditReportGenerator:
+    def save_report(self, file_path: str, output_format: str = "json"):
+        """
+        Save the report to disk in the specified format (json, markdown, html).
+        """
+        content = self.export_report(output_format)
+        mode = "w"
+        encoding = "utf-8"
+        with open(file_path, mode, encoding=encoding) as f:
+            f.write(content)
     def filter_findings(self, severity: str = None, finding_type: str = None) -> Dict[str, Any]:
         """
         Returns filtered findings from static and dynamic analysis by severity and/or type.


### PR DESCRIPTION
Added save_report method to AuditReportGenerator for direct file export in any supported format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced an audit report generator that aggregates static and dynamic findings, adds metadata and scores, and produces summary statistics.
  * Supports filtering findings by severity/type and exporting reports to JSON, Markdown, or HTML, with the ability to save to disk.
  * Added per-adapter timeout support for static analysis.

* Bug Fixes
  * Improved resilience in static analysis by isolating adapter errors so one failure no longer aborts the entire batch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->