### PR TITLE
feat: Add readiness and metrics endpoints to OAL Agent API

### DIFF
--- a/src/oal_agent/app/main.py
+++ b/src/oal_agent/app/main.py
@@ -26,3 +26,13 @@ async def root():
 async def health():
     """Health check endpoint."""
     return {"status": "healthy"}
+
+@app.get("/ready")
+async def ready():
+    """Readiness check endpoint."""
+    return {"status": "ready"}
+
+@app.get("/metrics")
+async def metrics():
+    """Metrics endpoint."""
+    return {"metrics": "Not implemented yet"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness endpoint (/ready) that returns a simple status to confirm the service is operational.
  * Introduced a metrics endpoint (/metrics) that currently returns a placeholder response.
  * Existing endpoints and behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->